### PR TITLE
Fix aditional periods between name and version in the archive file name

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ async function publish(config, context) {
     try {
         const info = await readInfoFile(config, context);
 
-        const archiveFile = [info.name, "_", info.version, ".zip"].join();
+        const archiveFile = [info.name, "_", info.version, ".zip"].join("");
         const archiveCommand = "git archive --format zip --prefix " + info.name +
                 "/ --worktree-attributes --output " + archiveFile + " HEAD";
 


### PR DESCRIPTION
name of packaged mod on github release:
before: MYMOD._.1.0.0.zip
now: MYMOD_1.0.0.zip

this happened because:
default behaviour for `[].join()` is to join using `","` added parameter `""`
this created the local file "MYMOD,_,1.0.0,.zip" which then got renamed to the file above by the github artefact uploader (replaced comma with period and removed double period infront of extension)